### PR TITLE
ALE: useful defaults for bash/C/C++/Python workflows

### DIFF
--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -158,9 +158,12 @@ nnoremap <silent> <leader>z :Goyo<cr>
 " => Ale (syntax checker and linter)
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let g:ale_linters = {
+\   'bash': ['shellcheck'],
+\   'c': ['clangd'],
+\   'cpp': ['clangd'],
 \   'javascript': ['eslint'],
 \   'python': ['flake8'],
-\   'go': ['go', 'golint', 'errcheck']
+\   'sh': ['shellcheck']
 \}
 
 nmap <silent> <leader>a <Plug>(ale_next_wrap)


### PR DESCRIPTION
Extends ALE defaults for common workflows: bash/sh via shellcheck, C/C++ via clangd, keeps Python flake8 and JavaScript eslint.