### PR TITLE
Add vim-tmux-navigator for seamless tmux/Vim movement

### DIFF
--- a/sources_non_forked/vim-tmux-navigator/.github/workflows/main.yml
+++ b/sources_non_forked/vim-tmux-navigator/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    name: Unit tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check bash shell version
+        run: bash --version
+      - name: Unit tests (file pattern-check)
+        run: TERM='xterm-256color' bash pattern-check

--- a/sources_non_forked/vim-tmux-navigator/.gitignore
+++ b/sources_non_forked/vim-tmux-navigator/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/sources_non_forked/vim-tmux-navigator/License.md
+++ b/sources_non_forked/vim-tmux-navigator/License.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Chris Toomey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sources_non_forked/vim-tmux-navigator/README.md
+++ b/sources_non_forked/vim-tmux-navigator/README.md
@@ -1,0 +1,578 @@
+Vim Tmux Navigator
+==================
+
+[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/christoomey/vim-tmux-navigator/main.yml?style=flat-square&logo=github)](https://github.com/christoomey/vim-tmux-navigator/actions/workflows/main.yml)
+
+This plugin is a repackaging of [Mislav Marohnić's](https://mislav.net/) tmux-navigator
+configuration described in [this gist][]. When combined with a set of tmux
+key bindings, the plugin will allow you to navigate seamlessly between
+vim and tmux splits using a consistent set of hotkeys.
+
+**NOTE**: This requires tmux v1.8 or higher.
+
+Usage
+-----
+
+This plugin provides the following mappings which allow you to move between
+Vim panes and tmux splits seamlessly.
+
+- `<ctrl-h>` => Left
+- `<ctrl-j>` => Down
+- `<ctrl-k>` => Up
+- `<ctrl-l>` => Right
+- `<ctrl-\>` => Previous split
+
+**Note** - you don't need to use your tmux `prefix` key sequence before using
+the mappings.
+
+If you want to use alternate key mappings, see the [configuration section
+below][].
+
+Installation
+------------
+
+### Vim
+
+If you don't have a preferred installation method, I recommend using [Vundle][].
+Assuming you have Vundle installed and configured, the following steps will
+install the plugin:
+
+Add the following line to your `~/.vimrc` file
+
+``` vim
+Plugin 'christoomey/vim-tmux-navigator'
+```
+
+Then run
+
+```
+:PluginInstall
+```
+
+If you are using Vim 8+, you don't need any plugin manager. Simply clone this repository inside `~/.vim/pack/plugin/start/` directory and restart Vim.
+
+```
+git clone git@github.com:christoomey/vim-tmux-navigator.git ~/.vim/pack/plugins/start/vim-tmux-navigator
+```
+
+### lazy.nvim
+
+If you are using [lazy.nvim](https://github.com/folke/lazy.nvim). Add the following plugin to your configuration.
+
+```lua
+{
+  "christoomey/vim-tmux-navigator",
+  cmd = {
+    "TmuxNavigateLeft",
+    "TmuxNavigateDown",
+    "TmuxNavigateUp",
+    "TmuxNavigateRight",
+    "TmuxNavigatePrevious",
+    "TmuxNavigatorProcessList",
+  },
+  keys = {
+    { "<c-h>", "<cmd><C-U>TmuxNavigateLeft<cr>" },
+    { "<c-j>", "<cmd><C-U>TmuxNavigateDown<cr>" },
+    { "<c-k>", "<cmd><C-U>TmuxNavigateUp<cr>" },
+    { "<c-l>", "<cmd><C-U>TmuxNavigateRight<cr>" },
+    { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
+  },
+}
+```
+
+Then, restart Neovim and lazy.nvim will automatically install the plugin and configure the keybindings.
+
+### tmux
+
+To configure the tmux side of this customization there are two options:
+
+#### Add a snippet
+
+Add the following to your `~/.tmux.conf` file:
+
+``` tmux
+# Smart pane switching with awareness of Vim splits.
+# See: https://github.com/christoomey/vim-tmux-navigator
+vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
+bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
+bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
+bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
+bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
+tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
+if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
+    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
+    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+
+bind-key -T copy-mode-vi 'C-h' select-pane -L
+bind-key -T copy-mode-vi 'C-j' select-pane -D
+bind-key -T copy-mode-vi 'C-k' select-pane -U
+bind-key -T copy-mode-vi 'C-l' select-pane -R
+bind-key -T copy-mode-vi 'C-\' select-pane -l
+```
+
+#### TPM
+
+If you prefer, you can use the Tmux Plugin Manager ([TPM][]) instead of
+copying the snippet.
+When using TPM, add the following lines to your ~/.tmux.conf:
+
+``` tmux
+set -g @plugin 'christoomey/vim-tmux-navigator'
+```
+
+To set a different key-binding, use the plugin configuration settings
+(remember to update your vim config accordingly).
+Multiple key bindings are possible, use a space to separate.
+
+``` tmux
+set -g @vim_navigator_mapping_left "C-Left C-h"  # use C-h and C-Left
+set -g @vim_navigator_mapping_right "C-Right C-l"
+set -g @vim_navigator_mapping_up "C-k"
+set -g @vim_navigator_mapping_down "C-j"
+set -g @vim_navigator_mapping_prev ""  # removes the C-\ binding
+```
+
+To disable the automatic mapping of `<prefix> C-l` to `send C-l` (which is
+intended to restore the "clear screen" functionality):
+
+```tmux
+set -g @vim_navigator_prefix_mapping_clear_screen ""
+```
+
+You can also customize how tmux detects instances of `vim`. Override the
+following options:
+
+``` tmux
+# Change the regular expression used to detect vim. This pattern must be
+# compatible with `grep -iE` extended regular expression syntax.
+set -g @vim_navigator_pattern '(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
+
+# Override the shell script logic for detecting vim. Instances of
+# '@vim_navigator_pattern' will automatically be substituted with your override
+# of '@vim_navigator_pattern', or it will use the default @vim_navigator_pattern
+# if you haven't overridden the option.
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+  | grep -iqE '^[^TXZ ]+ +@vim_navigator_pattern$'"
+set -g @vim_navigator_check "${is_vim}"
+```
+
+Don't forget to run tpm:
+
+``` tmux
+run '~/.tmux/plugins/tpm/tpm'
+```
+
+Thanks to Christopher Sexton who provided the updated tmux configuration in
+[this blog post][].
+
+Configuration
+-------------
+
+### Custom Key Bindings
+
+If you don't want the plugin to create any mappings, you can use the five
+provided functions to define your own custom maps. You will need to define
+custom mappings in your `~/.vimrc` as well as update the bindings in tmux to
+match.
+
+#### Vim
+
+Add the following to your `~/.vimrc` to define your custom maps:
+
+``` vim
+let g:tmux_navigator_no_mappings = 1
+
+nnoremap <silent> {Left-Mapping} :<C-U>TmuxNavigateLeft<cr>
+nnoremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
+nnoremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
+nnoremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
+nnoremap <silent> {Previous-Mapping} :<C-U>TmuxNavigatePrevious<cr>
+```
+
+*Note* Each instance of `{Left-Mapping}` or `{Down-Mapping}` must be replaced
+in the above code with the desired mapping. Ie, the mapping for `<ctrl-h>` =>
+Left would be created with `nnoremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>`.
+
+##### Autosave on leave
+
+You can configure the plugin to write the current buffer, or all buffers, when
+navigating from Vim to tmux. This functionality is exposed via the
+`g:tmux_navigator_save_on_switch` variable, which can have either of the
+following values:
+
+Value  | Behavior
+------ | ------
+1      | `:update` (write the current buffer, but only if changed)
+2      | `:wall` (write all buffers)
+
+To enable this, add the following (with the desired value) to your ~/.vimrc:
+
+```vim
+" Write all buffers before navigating from Vim to tmux pane
+let g:tmux_navigator_save_on_switch = 2
+```
+
+##### Disable While Zoomed
+
+By default, if you zoom the tmux pane running Vim and then attempt to navigate
+"past" the edge of the Vim session, tmux will unzoom the pane. This is the
+default tmux behavior, but may be confusing if you've become accustomed to
+navigation "wrapping" around the sides due to this plugin.
+
+We provide an option, `g:tmux_navigator_disable_when_zoomed`, which can be used
+to disable this unzooming behavior, keeping all navigation within Vim until the
+tmux pane is explicitly unzoomed.
+
+To disable navigation when zoomed, add the following to your ~/.vimrc:
+
+```vim
+" Disable tmux navigator when zooming the Vim pane
+let g:tmux_navigator_disable_when_zoomed = 1
+```
+
+If you are using TPM, you can also configure this behavior on the tmux side by
+adding the following to your ~/.tmux.conf:
+
+```tmux
+set -g @tmux_navigator_disable_when_zoomed "1"
+```
+
+This will prevent navigation to other tmux panes when the current pane is zoomed.
+
+##### Preserve Zoom
+
+As noted above, navigating from a Vim pane to another tmux pane normally causes
+the window to be unzoomed. Some users may prefer the behavior of tmux's `-Z`
+option to `select-pane`, which keeps the window zoomed if it was zoomed. To
+enable this behavior, set the `g:tmux_navigator_preserve_zoom` option to `1`:
+
+```vim
+" If the tmux window is zoomed, keep it zoomed when moving from Vim to another pane
+let g:tmux_navigator_preserve_zoom = 1
+```
+
+Naturally, if `g:tmux_navigator_disable_when_zoomed` is enabled, this option
+will have no effect.
+
+#### Tmux
+
+Alter each of the five lines of the tmux configuration listed above to use your
+custom mappings. **Note** each line contains two references to the desired
+mapping.
+
+### Additional Customization
+
+#### Ignoring programs that use Ctrl+hjkl movement
+
+In interactive programs such as FZF or the built-in Vim terminal, Ctrl+hjkl can be used instead of the arrow keys to move the selection up and down. If vim-tmux-navigator is getting in your way trying to change the active window instead, you can make it be ignored and work as if this plugin were not enabled. Just modify the `is_vim` variable(that you have either on the snipped you pasted on `~/.tmux.conf` or on the `vim-tmux-navigator.tmux` file). For example, to add the program `foobar`:
+
+```diff
+- vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
++ vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf|foobar)(diff)?(-wrapped)?'
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
+
+# Or, use the plugin config option:
+set -g @vim_navigator_pattern '(\S+/)?g?\.?(view|l?n?vim?x?|fzf|foobar)(diff)?(-wrapped)?'
+```
+
+#### Restoring Clear Screen (C-l)
+
+The default key bindings include `<Ctrl-l>` which is the readline key binding
+for clearing the screen. The following binding can be added to your `~/.tmux.conf` file to provide an alternate mapping to `clear-screen`.
+
+``` tmux
+bind C-l send-keys 'C-l'
+```
+
+With this enabled you can use `<prefix> C-l` to clear the screen.
+
+Thanks to [Brian Hogan][] for the tip on how to re-map the clear screen binding.
+
+#### Restoring SIGQUIT (C-\\)
+
+The default key bindings also include `<Ctrl-\>` which is the default method of
+sending SIGQUIT to a foreground process. Similar to "Clear Screen" above, a key
+binding can be created to replicate SIGQUIT in the prefix table.
+
+``` tmux
+bind C-\\ send-keys 'C-\'
+```
+
+Alternatively, you can exclude the previous pane key binding from your `~/.tmux.conf`. If using TPM, the following line can be used to unbind the previous pane binding set by the plugin.
+
+``` tmux
+unbind -n C-\\
+```
+
+#### Disable Wrapping
+
+By default, if you try to move past the edge of the screen, tmux/vim will
+"wrap" around to the opposite side. To disable this, you'll need to
+configure both tmux and vim:
+
+For vim, you only need to enable this option:
+```vim
+let  g:tmux_navigator_no_wrap = 1
+```
+
+Tmux doesn't have an option, so whatever key bindings you have need to be set
+to conditionally wrap based on position on screen:
+
+```tmux
+vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
+bind-key -n 'C-h' if-shell "$is_vim" { send-keys C-h } { if-shell -F '#{pane_at_left}'   {} { select-pane -L } }
+bind-key -n 'C-j' if-shell "$is_vim" { send-keys C-j } { if-shell -F '#{pane_at_bottom}' {} { select-pane -D } }
+bind-key -n 'C-k' if-shell "$is_vim" { send-keys C-k } { if-shell -F '#{pane_at_top}'    {} { select-pane -U } }
+bind-key -n 'C-l' if-shell "$is_vim" { send-keys C-l } { if-shell -F '#{pane_at_right}'  {} { select-pane -R } }
+
+bind-key -T copy-mode-vi 'C-h' if-shell -F '#{pane_at_left}'   {} { select-pane -L }
+bind-key -T copy-mode-vi 'C-j' if-shell -F '#{pane_at_bottom}' {} { select-pane -D }
+bind-key -T copy-mode-vi 'C-k' if-shell -F '#{pane_at_top}'    {} { select-pane -U }
+bind-key -T copy-mode-vi 'C-l' if-shell -F '#{pane_at_right}'  {} { select-pane -R }
+```
+
+#### Nesting
+If you like to nest your tmux sessions, this plugin is not going to work
+properly. It probably never will, as it would require detecting when Tmux would
+wrap from one outermost pane to another and propagating that to the outer
+session.
+
+By default this plugin works on the outermost tmux session and the vim
+sessions it contains, but you can customize the behaviour by adding more
+commands to the expression used by the grep command.
+
+When nesting tmux sessions via ssh or mosh, you could extend it to look like:
+
+```diff
+- vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
++ vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf|ssh|mosh)(diff)?(-wrapped)?'
+
+# Or, use the plugin config option:
+set -g @vim_navigator_pattern '(\S+/)?g?\.?(view|l?n?vim?x?|fzf|ssh|mosh)(diff)?(-wrapped)?'
+```
+
+This configuration makes this plugin work within the innermost tmux session and
+the vim sessions within that one. This works better than the default behaviour
+if you use the outer Tmux sessions as relays to different hosts and have all
+instances of vim on remote hosts.
+
+Similarly, if you like to nest tmux locally, add `|tmux` to the expression.
+
+This behaviour means that you can't leave the innermost session with Ctrl-hjkl
+directly. These following fallback mappings can be targeted to the right Tmux
+session by escaping the prefix (Tmux' `send-prefix` command).
+
+``` tmux
+bind -r C-h run "tmux select-pane -L"
+bind -r C-j run "tmux select-pane -D"
+bind -r C-k run "tmux select-pane -U"
+bind -r C-l run "tmux select-pane -R"
+bind -r C-\ run "tmux select-pane -l"
+```
+
+Another workaround is to configure tmux on the outer machine to send keys to
+the inner tmux session:
+
+```
+bind-key -n 'M-h' 'send-keys c-h'
+bind-key -n 'M-j' 'send-keys c-j'
+bind-key -n 'M-k' 'send-keys c-k'
+bind-key -n 'M-l' 'send-keys c-l'
+```
+
+Here we bind "meta" key (aka "alt" or "option" key) combinations for each of
+the four directions and send those along to the innermost session via
+`send-keys`. You use the normal `C-h,j,k,l` while in the outermost session and
+the alternative bindings to navigate the innermost session. Note that if you
+use the example above on a Mac, you may need to configure your terminal app to
+get the option key to work like a normal meta key. Consult your terminal app's
+manual for details.
+
+A third possible solution is to manually prevent the outermost tmux session
+from intercepting the navigation keystrokes by disabling the prefix table:
+
+```
+set -g pane-active-border-style 'fg=#000000,bg=#ffff00'
+bind -T root F12  \
+  set prefix None \;\
+  set key-table off \;\
+  if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
+  set -g pane-active-border-style 'fg=#000000,bg=#00ff00'
+  refresh-client -S \;\
+
+bind -T off F12 \
+  set -u prefix \;\
+  set -u key-table \;\
+  set -g pane-active-border-style 'fg=#000000,bg=#ffff00'
+  refresh-client -S
+```
+
+This code, added to the machine running the outermost tmux session, toggles the
+outermost prefix table on and off with the `F12` key. When off, the active
+pane's border changes to green to indicate that the inner session receives
+navigation keystrokes. When toggled back on, the border returns to yellow and
+normal operation resumes and the outermost responds to the nav keystrokes.
+
+The code example above also toggles the prefix key (ctrl-b by default) for the
+outer session so that same prefix can be temporarily used on the inner session
+instead of having to use a different prefix (ctrl-a by default) which you may
+find convenient. If not, simply remove the lines that set/unset the prefix key
+from the code example above.
+
+#### netrw
+
+Vim's builtin file explorer, named the netrw plugin, has a default keymapping
+for `<C-l>`. When using `vim-tmux-navigator` with default settings,
+`vim-tmux-navigator` will try to override the netrw mapping so that `<C-l>` will
+still be mapped to `:TmuxNavigateRight` as it is for other buffers. If you
+prefer to keep the netrw mapping, set this variable in your vimrc:
+
+``` vim
+let g:tmux_navigator_disable_netrw_workaround = 1
+```
+
+Alternatively, if you prefer to work around the issue yourself, you can add the
+following to your vimrc:
+
+``` vim
+let g:tmux_navigator_disable_netrw_workaround = 1
+" g:Netrw_UserMaps is a list of lists. If you'd like to add other key mappings,
+" just add them like so: [['a', 'command1'], ['b', 'command2'], ...]
+let g:Netrw_UserMaps = [['<C-l>', '<C-U>TmuxNavigateRight<cr>']]
+```
+
+#### Faster performance
+
+By default, this plugin relies on `ps -o state= -o comm= -t` to detect whether
+the current pane is running vim or not. If the `ps` command is slow, then you
+may be able to optimize the performance in common cases by customizing
+`@vim_navigator_check` like so:
+
+``` tmux
+is_vim="\
+echo '#{pane_current_command}' | grep -iqE '^@vim_navigator_pattern$' && exit 0
+echo '#{pane_current_command}' | grep -iqE '^(bash|zsh|fish)$' && exit 1
+ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +@vim_navigator_pattern$'"
+set -g @vim_navigator_check "${is_vim}"
+```
+
+Troubleshooting
+---------------
+
+### Vim -> Tmux doesn't work!
+
+This is likely due to conflicting key mappings in your `~/.vimrc`. You can check
+this by running `:verbose nmap <C-h>` (similar for each of the key bindings).
+You should see vim-tmux-runner as the source listed for the key binding, but if
+you see something else, you've got a conflict and will need to remove the other
+key binding or otherwise restructure your vim config.
+
+Another option is that the pattern matching included in the `.tmux.conf` is
+not recognizing that Vim is active. To check that tmux is properly recognizing
+Vim, use the provided Vim command `:TmuxNavigatorProcessList`. The output of
+that command should be a list like:
+
+```
+Ss   -zsh
+S+   vim
+S+   tmux
+```
+
+If you encounter a different output please [open an issue][] with as much info
+about your OS, Vim version, and tmux version as possible.
+
+[open an issue]: https://github.com/christoomey/vim-tmux-navigator/issues/new
+
+### Tmux Can't Tell if Vim Is Active
+
+This functionality requires tmux version 1.8 or higher. You can check your
+version to confirm with this shell command:
+
+``` bash
+tmux -V # should return 'tmux 1.8'
+```
+
+### Switching out of Vim Is Slow
+
+If you find that navigation within Vim (from split to split) is fine, but Vim
+to a non-Vim tmux pane is delayed, it might be due to a slow shell startup.
+Consider moving code from your shell's non-interactive rc file (e.g.,
+`~/.zshenv`) into the interactive startup file (e.g., `~/.zshrc`) as Vim only
+sources the non-interactive config.
+
+### It doesn't work in Vim's `terminal` mode
+
+Terminal mode is now supported :)
+
+### It Doesn't Work in tmate
+
+[tmate][] is a tmux fork that aids in setting up remote pair programming
+sessions. It is designed to run alongside tmux without issue, but occasionally
+there are hiccups. Specifically, if the versions of tmux and tmate don't match,
+you can have issues. See [this
+issue](https://github.com/christoomey/vim-tmux-navigator/issues/27) for more
+detail.
+
+[tmate]: http://tmate.io/
+
+### Switching between host panes doesn't work when docker is running
+
+Images built from minimalist OSes may not have the `ps` command or have a
+simpler version of the command that is not compatible with this plugin.
+Try installing the `procps` package using the appropriate package manager
+command. For Alpine, you would do `apk add procps`.
+
+If this doesn't solve your problem, you can also try the following:
+
+Replace the `is_vim` variable in your `~/.tmux.conf` file with:
+```tmux
+vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
+if-shell '[ -f /.dockerenv ]' \
+  "is_vim=\"ps -o state=,comm= -t '#{pane_tty}' \
+      | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'\""
+  # Filter out docker instances of nvim from the host system to prevent
+  # host from thinking nvim is running in a pseudoterminal when its not.
+  "is_vim=\"ps -o state=,comm=,cgroup= -t '#{pane_tty}' \
+      | grep -ivE '^.+ +.+ +.+\\/docker\\/.+$' \
+      | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'\""
+
+# Or, use the plugin config option:
+if-shell '[ -f /.dockerenv ]' \
+  "is_vim=\"ps -o state=,comm= -t '#{pane_tty}' \
+      | grep -iqE '^[^TXZ ]+ +@vim_navigator_pattern$'\""
+  # Filter out docker instances of nvim from the host system to prevent
+  # host from thinking nvim is running in a pseudoterminal when its not.
+  "is_vim=\"ps -o state=,comm=,cgroup= -t '#{pane_tty}' \
+      | grep -ivE '^.+ +.+ +.+\\/docker\\/.+$' \
+      | grep -iqE '^[^TXZ ]+ +@vim_navigator_pattern$'\""
+set -g @vim_navigator_check "${is_vim}"
+```
+
+Details: The output of the ps command on the host system includes processes
+running within containers, but containers have their own instances of
+/dev/pts/\*. vim-tmux-navigator relies on /dev/pts/\* to determine if vim is
+running, so if vim is running in say /dev/pts/<N> in a container and there is a
+tmux pane (not running vim) in /dev/pts/<N> on the host system, then without
+the patch above vim-tmux-navigator will think vim is running when its not.
+
+### It Still Doesn't Work!!!
+
+The tmux configuration uses an inlined grep pattern match to help determine if
+the current pane is running Vim. If you run into any issues with the navigation
+not happening as expected, you can try using [Mislav's original external
+script][] which has a more robust check.
+
+[Brian Hogan]: https://twitter.com/bphogan
+[Mislav's original external script]: https://github.com/mislav/dotfiles/blob/master/bin/tmux-vim-select-pane
+[Vundle]: https://github.com/gmarik/vundle
+[TPM]: https://github.com/tmux-plugins/tpm
+[configuration section below]: #custom-key-bindings
+[this blog post]: http://www.codeography.com/2013/06/19/navigating-vim-and-tmux-splits
+[this gist]: https://gist.github.com/mislav/5189704

--- a/sources_non_forked/vim-tmux-navigator/doc/tmux-navigator.txt
+++ b/sources_non_forked/vim-tmux-navigator/doc/tmux-navigator.txt
@@ -1,0 +1,42 @@
+*tmux-navigator.txt* Plugin to allow seamless navigation between tmux and vim
+
+==============================================================================
+CONTENTS                               *tmux-navigator-contents*
+
+
+==============================================================================
+INTRODUCTION                           *tmux-navigator*
+
+Vim-tmux-navigator is a little plugin which enables seamless navigation
+between tmux panes and vim splits. This plugin is a repackaging of Mislav
+Marohinc's tmux=navigator configuration. When combined with a set of tmux key
+bindings, the plugin will allow you to navigate seamlessly between vim and
+tmux splits using a consistent set of hotkeys.
+
+NOTE: This requires tmux v1.8 or higher.
+
+==============================================================================
+CONFIGURATION                             *tmux-navigator-configuration*
+
+* Activate autoupdate on exit
+ let g:tmux_navigator_save_on_switch = 1
+
+* Disable vim->tmux navigation when the Vim pane is zoomed in tmux
+ let g:tmux_navigator_disable_when_zoomed = 1
+
+* If the Vim pane is zoomed, stay zoomed when moving to another tmux pane
+ let g:tmux_navigator_preserve_zoom = 1
+
+* Custom Key Bindings
+ let g:tmux_navigator_no_mappings = 1
+
+ nnoremap <silent> {Left-mapping} :<C-U>TmuxNavigateLeft<cr>
+ nnoremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
+ nnoremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
+ nnoremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
+ nnoremap <silent> {Previous-Mapping} :<C-U><C-U>TmuxNavigatePrevious<cr>
+
+* Disable the <C-l> remapping on netrw buffers (use netrw's mapping)
+ let g:tmux_navigator_disable_netrw_workaround = 1
+
+ vim:tw=78:ts=8:ft=help:norl:

--- a/sources_non_forked/vim-tmux-navigator/pattern-check
+++ b/sources_non_forked/vim-tmux-navigator/pattern-check
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Collection of various test strings that could be the output of the tmux
+# 'pane_current_comamnd' message. Included as regression test for updates to
+# the inline grep pattern used in the `.tmux.conf` configuration
+
+set -e
+
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+NORMAL=$(tput sgr0)
+
+# Import 'vim_pattern'
+source 'vim-tmux-navigator.tmux'
+
+match_tests=(
+  vim
+  Vim
+  VIM
+  vimdiff
+  lvim
+  /usr/local/bin/vim
+  vi
+  gvim
+  view
+  gview
+  nvim
+  vimx
+  fzf
+  .vim-wrapped
+  .nvim-wrapped
+)
+no_match_tests=(
+  /Users/christoomey/.vim/thing
+  /usr/local/bin/start-vim
+  start-vim
+  this_is_not_vim
+  thisisnotvim
+  /vim/is/not/final/path/segment
+  file_with_extension.vim
+  tvim # there's not yet a vi clone named 'tvim', so the pattern shouldn't match
+)
+
+MATCH_RESULT="${GREEN}match${NORMAL}"
+NO_MATCH_RESULT="${RED}not match${NORMAL}"
+
+display_matches() {
+  local result
+  local final_status=0
+  for process_name in "$@"; do
+    result="$(matches_vim_pattern $process_name)"
+    if [[ "${result}" != "${expect_result}" ]]; then
+      final_status=1
+    fi
+    printf "%s %s\n" "${result}" "$process_name"
+  done
+  return "${final_status}"
+}
+
+matches_vim_pattern() {
+  if echo "$1" | grep -iqE "^${vim_pattern}$"; then
+    echo "${MATCH_RESULT}"
+  else
+    echo "${NO_MATCH_RESULT}"
+  fi
+}
+
+main() {
+  echo -e "Testing against pattern: ${YELLOW}$vim_pattern${NORMAL}\n"
+
+  local final_status=0
+  echo -e "These should all ${MATCH_RESULT}\n----------------------"
+  local expect_result="${MATCH_RESULT}"
+  display_matches "${match_tests[@]}" || final_status=1
+
+  echo -e "\nThese should all ${NO_MATCH_RESULT}\n--------------------------"
+  expect_result="${NO_MATCH_RESULT}"
+  display_matches "${no_match_tests[@]}" || final_status=1
+
+  if [[ "${final_status}" == 0 ]]; then
+    echo -e "\n${GREEN}All test cases passed!${NORMAL}"
+  else
+    echo -e "\n${RED}Some test cases are failing${NORMAL}"
+  fi
+
+  # Find lines in README.md which redefine 'vim_pattern' so that we can make
+  # sure it matches the canonical definition in vim-tmux-navigator.tmux. This
+  # includes lines starting with '- vim_pattern', however it skips
+  # '+ vim_pattern' since those lines indicate intentional modifications and
+  # need manual review.
+  IFS='
+'
+  local -a pattern_copies=($(sed -En "s/^\s*(- )?vim_pattern='(.*)'/\2/p" README.md))
+
+  local pattern_copy
+  local readme_status=0
+  echo -e "\nChecking README.md documentation"
+  for pattern_copy in "${pattern_copies[@]}"; do
+    if [[ "${vim_pattern}" != "${pattern_copy}" ]]; then
+      echo -n "Update 'vim_pattern' in README.md "
+      echo -n "(current line: ${RED}'${pattern_copy}'${NORMAL}) "
+      echo "to match ${GREEN}'${vim_pattern}'${NORMAL}"
+      readme_status=1
+    fi
+  done
+  if [[ "${readme_status}" == 0 ]]; then
+    echo -e "\n${GREEN}README.md is up to date${NORMAL}"
+  else
+    echo -e "\n${RED}Update README.md to fix defintions of 'vim_pattern'${NORMAL}"
+    final_status="${readme_status}"
+  fi
+
+  return "${final_status}"
+}
+
+main

--- a/sources_non_forked/vim-tmux-navigator/plugin/tmux_navigator.vim
+++ b/sources_non_forked/vim-tmux-navigator/plugin/tmux_navigator.vim
@@ -1,0 +1,158 @@
+" Maps <C-h/j/k/l> to switch vim splits in the given direction. If there are no more windows in that direction, forwards the operation to tmux.
+" Additionally, <C-\> toggles between last active vim splits/tmux panes.
+
+if exists("g:loaded_tmux_navigator") || &cp || v:version < 700
+  finish
+endif
+let g:loaded_tmux_navigator = 1
+
+function! s:VimNavigate(direction)
+  try
+    execute 'wincmd ' . a:direction
+  catch
+    echohl ErrorMsg | echo 'E11: Invalid in command-line window; <CR> executes, CTRL-C quits: wincmd k' | echohl None
+  endtry
+endfunction
+
+if !get(g:, 'tmux_navigator_no_mappings', 0)
+  nnoremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>
+  nnoremap <silent> <c-j> :<C-U>TmuxNavigateDown<cr>
+  nnoremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
+  nnoremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
+  nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
+
+  if !empty($TMUX)
+    function! IsFZF()
+      return &ft == 'fzf'
+    endfunction
+    tnoremap <expr> <silent> <C-h> IsFZF() ? "\<C-h>" : "\<C-w>:\<C-U> TmuxNavigateLeft\<cr>"
+    tnoremap <expr> <silent> <C-j> IsFZF() ? "\<C-j>" : "\<C-w>:\<C-U> TmuxNavigateDown\<cr>"
+    tnoremap <expr> <silent> <C-k> IsFZF() ? "\<C-k>" : "\<C-w>:\<C-U> TmuxNavigateUp\<cr>"
+    tnoremap <expr> <silent> <C-l> IsFZF() ? "\<C-l>" : "\<C-w>:\<C-U> TmuxNavigateRight\<cr>"
+  endif
+
+  if !get(g:, 'tmux_navigator_disable_netrw_workaround', 0)
+    if !exists('g:Netrw_UserMaps')
+      let g:Netrw_UserMaps = [['<C-l>', '<C-U>TmuxNavigateRight<cr>']]
+    else
+      echohl ErrorMsg | echo 'vim-tmux-navigator conflicts with netrw <C-l> mapping. See https://github.com/christoomey/vim-tmux-navigator#netrw or add `let g:tmux_navigator_disable_netrw_workaround = 1` to suppress this warning.' | echohl None
+    endif
+  endif
+endif
+
+if empty($TMUX)
+  command! TmuxNavigateLeft call s:VimNavigate('h')
+  command! TmuxNavigateDown call s:VimNavigate('j')
+  command! TmuxNavigateUp call s:VimNavigate('k')
+  command! TmuxNavigateRight call s:VimNavigate('l')
+  command! TmuxNavigatePrevious call s:VimNavigate('p')
+  finish
+endif
+
+command! TmuxNavigateLeft call s:TmuxAwareNavigate('h')
+command! TmuxNavigateDown call s:TmuxAwareNavigate('j')
+command! TmuxNavigateUp call s:TmuxAwareNavigate('k')
+command! TmuxNavigateRight call s:TmuxAwareNavigate('l')
+command! TmuxNavigatePrevious call s:TmuxAwareNavigate('p')
+
+if !exists("g:tmux_navigator_save_on_switch")
+  let g:tmux_navigator_save_on_switch = 0
+endif
+
+if !exists("g:tmux_navigator_disable_when_zoomed")
+  let g:tmux_navigator_disable_when_zoomed = 0
+endif
+
+if !exists("g:tmux_navigator_preserve_zoom")
+  let g:tmux_navigator_preserve_zoom = 0
+endif
+
+if !exists("g:tmux_navigator_no_wrap")
+  let g:tmux_navigator_no_wrap = 0
+endif
+
+let s:pane_position_from_direction = {'h': 'left', 'j': 'bottom', 'k': 'top', 'l': 'right'}
+
+function! s:TmuxOrTmateExecutable()
+  return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
+endfunction
+
+function! s:TmuxVimPaneIsZoomed()
+  return s:TmuxCommand("display-message -p '#{window_zoomed_flag}'") == 1
+endfunction
+
+function! s:TmuxSocket()
+  " The socket path is the first value in the comma-separated list of $TMUX.
+  return split($TMUX, ',')[0]
+endfunction
+
+function! s:TmuxCommand(args)
+  let cmd = s:TmuxOrTmateExecutable() . ' -S ' . s:TmuxSocket() . ' ' . a:args
+  let l:x=&shellcmdflag
+  let &shellcmdflag='-c'
+  let retval=system(cmd)
+  let &shellcmdflag=l:x
+  return retval
+endfunction
+
+function! s:TmuxNavigatorProcessList()
+  echo s:TmuxCommand("run-shell 'ps -o state= -o comm= -t ''''#{pane_tty}'''''")
+endfunction
+command! TmuxNavigatorProcessList call s:TmuxNavigatorProcessList()
+
+let s:tmux_is_last_pane = 0
+augroup tmux_navigator
+  au!
+  autocmd WinEnter * let s:tmux_is_last_pane = 0
+augroup END
+
+function! s:NeedsVitalityRedraw()
+  return exists('g:loaded_vitality') && v:version < 704 && !has("patch481")
+endfunction
+
+function! s:ShouldForwardNavigationBackToTmux(tmux_last_pane, at_tab_page_edge)
+  if g:tmux_navigator_disable_when_zoomed && s:TmuxVimPaneIsZoomed()
+    return 0
+  endif
+  return a:tmux_last_pane || a:at_tab_page_edge
+endfunction
+
+
+function! s:TmuxAwareNavigate(direction)
+  let nr = winnr()
+  let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
+  if !tmux_last_pane
+    call s:VimNavigate(a:direction)
+  endif
+  let at_tab_page_edge = (nr == winnr())
+  " Forward the switch panes command to tmux if:
+  " a) we're toggling between the last tmux pane;
+  " b) we tried switching windows in vim but it didn't have effect.
+  if s:ShouldForwardNavigationBackToTmux(tmux_last_pane, at_tab_page_edge)
+    if g:tmux_navigator_save_on_switch == 1
+      try
+        update " save the active buffer. See :help update
+      catch /^Vim\%((\a\+)\)\=:E32/ " catches the no file name error
+      endtry
+    elseif g:tmux_navigator_save_on_switch == 2
+      try
+        wall " save all the buffers. See :help wall
+      catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error
+      endtry
+    endif
+    let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+    if g:tmux_navigator_preserve_zoom == 1
+      let l:args .= ' -Z'
+    endif
+    if g:tmux_navigator_no_wrap == 1 && a:direction != 'p'
+      let args = 'if -F "#{pane_at_' . s:pane_position_from_direction[a:direction] . '}" "" "' . args . '"'
+    endif
+    silent call s:TmuxCommand(args)
+    if s:NeedsVitalityRedraw()
+      redraw!
+    endif
+    let s:tmux_is_last_pane = 1
+  else
+    let s:tmux_is_last_pane = 0
+  endif
+endfunction

--- a/sources_non_forked/vim-tmux-navigator/vim-tmux-navigator.tmux
+++ b/sources_non_forked/vim-tmux-navigator/vim-tmux-navigator.tmux
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+get_tmux_option() {
+  local option value default
+  option="$1"
+  default="$2"
+  # NOTE: Older tmux versions (eg. 3.2a on Ubuntu 22.04) do not exit with an
+  #       error code when an option is not defined. Therefore we need to first
+  #       test if the option exists, and only then try to get its value or fall
+  #       back to the default.
+  value="$([[ -n $(tmux show-options -gq "$option") ]] \
+      && tmux show-option -gqv "$option" \
+      || echo "$default")"
+
+  # Deprecated, for backward compatibility
+  if [[ $value == 'null' ]]; then
+      echo ""
+      return
+  fi
+
+  echo "$value"
+}
+
+# Export 'vim_pattern' so that it can be tested in pattern-check
+declare vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
+
+bind_key_vim() {
+  local key tmux_cmd is_vim tmux_navigator_disable_when_zoomed
+  key="$1"
+  tmux_cmd="$2"
+
+  vim_pattern="$(get_tmux_option "@vim_navigator_pattern" "${vim_pattern}")"
+
+  is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+      | grep -iqE '^[^TXZ ]+ +"@vim_navigator_pattern"$'"
+  is_vim="$(get_tmux_option "@vim_navigator_check" "${is_vim}")"
+  is_vim="${is_vim//@vim_navigator_pattern/${vim_pattern}}"
+
+  tmux_navigator_disable_when_zoomed="$(get_tmux_option "@tmux_navigator_disable_when_zoomed" "0")"
+  if [ "$tmux_navigator_disable_when_zoomed" = "1" ]; then
+    tmux_cmd="if-shell -F '#{window_zoomed_flag}' '' '$tmux_cmd'"
+  fi
+
+  # sending C-/ according to https://github.com/tmux/tmux/issues/1827
+  tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
+  # tmux < 3.0 cannot parse "$tmux_cmd" as one argument, thus copying as multiple arguments
+  tmux bind-key -T copy-mode-vi "$key" $tmux_cmd
+}
+
+main() {
+  move_left="$(get_tmux_option "@vim_navigator_mapping_left" 'C-h')"
+  move_right="$(get_tmux_option "@vim_navigator_mapping_right" 'C-l')"
+  move_up="$(get_tmux_option "@vim_navigator_mapping_up" 'C-k')"
+  move_down="$(get_tmux_option "@vim_navigator_mapping_down" 'C-j')"
+  move_prev="$(get_tmux_option "@vim_navigator_mapping_prev" 'C-\')"
+
+  for k in $(echo "$move_left");  do bind_key_vim "$k" "select-pane -L"; done
+  for k in $(echo "$move_down");  do bind_key_vim "$k" "select-pane -D"; done
+  for k in $(echo "$move_up");    do bind_key_vim "$k" "select-pane -U"; done
+  for k in $(echo "$move_right"); do bind_key_vim "$k" "select-pane -R"; done
+  for k in $(echo "$move_prev");  do bind_key_vim "$k" "select-pane -l"; done
+
+  # Restoring clear screen
+  clear_screen="$(get_tmux_option "@vim_navigator_prefix_mapping_clear_screen" 'C-l')"
+  for k in $(echo "$clear_screen"); do tmux bind "$k" send-keys 'C-l'; done
+}
+
+if [ "$BASH_SOURCE" == "$0" ]; then
+  main "$@"
+fi

--- a/update_plugins.py
+++ b/update_plugins.py
@@ -54,6 +54,7 @@ vim-python-pep8-indent https://github.com/Vimjas/vim-python-pep8-indent
 vim-indent-guides https://github.com/nathanaelkane/vim-indent-guides
 mru.vim https://github.com/vim-scripts/mru.vim
 editorconfig-vim https://github.com/editorconfig/editorconfig-vim
+vim-tmux-navigator https://github.com/christoomey/vim-tmux-navigator
 dracula https://github.com/dracula/vim
 copilot.vim https://github.com/github/copilot.vim
 """.strip()

--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -77,6 +77,16 @@ ino <C-j> <C-r>=snipMate#TriggerSnippet()<cr>
 snor <C-j> <esc>i<right><C-r>=snipMate#TriggerSnippet()<cr>
 let g:snipMate = { 'snippet_version' : 1 }
 
+"
+" => tmux navigator (seamless Ctrl-h/j/k/l between Vim and tmux)
+"
+if exists(':TmuxNavigateLeft')
+  nnoremap <silent> <C-h> :TmuxNavigateLeft<CR>
+  nnoremap <silent> <C-j> :TmuxNavigateDown<CR>
+  nnoremap <silent> <C-k> :TmuxNavigateUp<CR>
+  nnoremap <silent> <C-l> :TmuxNavigateRight<CR>
+endif
+
 
 """"""""""""""""""""""""""""""
 " => Vim grep


### PR DESCRIPTION
Adds vim-tmux-navigator plugin (vendored + update script entry) and maps Ctrl-h/j/k/l to tmux-aware movement when plugin commands are available.